### PR TITLE
fix(plugin): Add missing dependsOn to Orca beans

### DIFF
--- a/orca-run-multiple-pipelines/src/main/java/io/armory/plugin/smp/RunMultiplePipelinesPlugin.java
+++ b/orca-run-multiple-pipelines/src/main/java/io/armory/plugin/smp/RunMultiplePipelinesPlugin.java
@@ -45,7 +45,7 @@ public class RunMultiplePipelinesPlugin extends SpringLoaderPlugin {
     private static final List<String> ORCA_BEANS_DEPENDING_ON_PLUGIN = List.of(
             "sqlConfiguration",
             "artifactUtils",
-            "redisOrcaQueueConfiguration",
+            "sqlOrcaQueueConfiguration",
             "dependentPipelineStarter"
     );
 


### PR DESCRIPTION
By adding the `dependsOn()` to these beans, we allow the plugin to load its own beans before Orca beans try to Autowire.